### PR TITLE
CVE-2023-27586 Don't allow fetching external URLs by default

### DIFF
--- a/cairosvg/__init__.py
+++ b/cairosvg/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # This file is part of CairoSVG
-# Copyright © 2010-2012 Kozea
+# Copyright (c) 2010-2012 Kozea
 #
 # This library is free software: you can redistribute it and/or modify it under
 # the terms of the GNU Lesser General Public License as published by the Free
@@ -24,10 +24,11 @@ import os
 import sys
 import optparse
 
+VERSION = '1.0.22'
+
 from . import surface
 
 
-VERSION = '1.0.22'
 SURFACES = {
     'SVG': surface.SVGSurface,  # Tell us if you actually use this one!
     'PNG': surface.PNGSurface,
@@ -65,7 +66,7 @@ def main():
         '-H', '--height', default=None, type="float",
         help='height of the parent container in pixels')
     option_parser.add_option(
-        '-u', '--unsafe', action='store_true',
+        '-u', '--unsafe', default=False, action='store_true',
         help='resolve XML entities (WARNING: vulnerable to XXE attacks)')
     option_parser.add_option(
         "-o", "--output",

--- a/cairosvg/parser.py
+++ b/cairosvg/parser.py
@@ -52,6 +52,7 @@ import os.path
 from .css import apply_stylesheets
 from .features import match_features
 from .surface.helpers import urls, rotations, pop_rotation, flatten
+from .url import fetch, safe_fetch, read_url, parse_url
 
 
 # Python 2/3 compat
@@ -104,7 +105,7 @@ NOT_INHERITED_ATTRS = frozenset([
 class Node(dict):
     """SVG node with dict-like properties and children."""
 
-    def __init__(self, node, parent=None, parent_children=False, url=None,
+    def __init__(self, node, url_fetcher, parent=None, parent_children=False, url=None, unsafe = False,
                 __not_inherited_attrs=NOT_INHERITED_ATTRS):
         """Create the Node from ElementTree ``node``, with ``parent`` Node."""
         self.children = ()
@@ -113,7 +114,8 @@ class Node(dict):
         self.tag = node.tag
         self.text = node.text
         self.node = node
-
+        self.url_fetcher = url_fetcher
+        self.unsafe = unsafe
         # Inherits from parent properties
         if parent is not None:
             self.update([
@@ -160,16 +162,19 @@ class Node(dict):
             self.children, _ = self.text_children(node, True, True)
 
         if parent_children:
-            self.children = [Node(child.node, parent=self)
+            self.children = [Node(child.node, self.url_fetcher, parent=self, unsafe=self.unsafe)
                              for child in parent.children]
         elif not self.children:
             self.children = []
             for child in node:
                 if isinstance(child.tag, basestring):
                     if match_features(child):
-                        self.children.append(Node(child, self))
+                        self.children.append(Node(child, self.url_fetcher, parent=self, unsafe=self.unsafe))
                         if self.tag == "switch":
                             break
+
+    def fetch_url(self, url, resource_type, get_child_fetcher=True):
+        return read_url(url, self.url_fetcher, resource_type)
 
     def text_children(self, node, trailing_space, text_root=False):
         """Create children and return them."""
@@ -190,18 +195,18 @@ class Node(dict):
                 href = child.get("{http://www.w3.org/1999/xlink}href")
                 tree_urls = urls(href)
                 url = tree_urls[0] if tree_urls else None
-                child_tree = Tree(url=url, parent=self)
+                child_tree = Tree(url=url, url_fetcher=self.url_fetcher, parent=self, unsafe=self.unsafe)
                 child_tree.clear()
                 child_tree.update(self)
                 child_node = Node(
-                    child, parent=child_tree, parent_children=True)
+                    child, self.url_fetcher, parent=child_tree, parent_children=True, unsafe=self.unsafe)
                 child_node.tag = "tspan"
                 # Retrieve the referenced node and get its flattened text
                 # and remove the node children.
                 child = child_tree.xml_tree
                 child.text = flatten(child)
             else:
-                child_node = Node(child, parent=self)
+                child_node = Node(child, self.url_fetcher, parent=self, unsafe=self.unsafe)
             child_preserve = child_node.get(space) == "preserve"
             child_node.text = handle_white_spaces(child.text, child_preserve)
             child_node.children, trailing_space = \
@@ -211,7 +216,7 @@ class Node(dict):
                 pop_rotation(child_node, original_rotate, rotate)
             children.append(child_node)
             if child.tail:
-                anonymous = Node(ElementTree.Element("tspan"), parent=self)
+                anonymous = Node(ElementTree.Element("tspan"), self.url_fetcher, parent=self, unsafe=self.unsafe)
                 anonymous.text = handle_white_spaces(child.tail, preserve)
                 if original_rotate:
                     pop_rotation(anonymous, original_rotate, rotate)
@@ -226,6 +231,9 @@ class Node(dict):
 
         return children, trailing_space
 
+    def get_href(self):
+        return self.get('{http://www.w3.org/1999/xlink}href', self.get('href'))
+
 
 class Tree(Node):
     """SVG tree."""
@@ -233,17 +241,22 @@ class Tree(Node):
         tree_cache = kwargs.get("tree_cache")
         if tree_cache:
             if "url" in kwargs:
-                url_parts = kwargs["url"].split("#", 1)
-                if len(url_parts) == 2:
-                    url, element_id = url_parts
-                else:
-                    url, element_id = url_parts[0], None
+                # url_parts = kwargs["url"].split("#", 1)
+                # if len(url_parts) == 2:
+                #     url, element_id = url_parts
+                # else:
+                #     url, element_id = url_parts[0], None
+                parsed_url = parse_url(kwargs['url'])
+                url = parsed_url.geturl()
+                element_id = parsed_url.fragment
+
                 parent = kwargs.get("parent")
+                unsafe = kwargs.get("unsafe")
                 if parent and not url:
                     url = parent.url
                 if (url, element_id) in tree_cache:
                     cached_tree = tree_cache[(url, element_id)]
-                    new_tree = Node(cached_tree.xml_tree, parent)
+                    new_tree = Node(cached_tree.xml_tree, cached_tree.url_fetcher, parent, unsafe=unsafe)
                     new_tree.xml_tree = cached_tree.xml_tree
                     new_tree.url = url
                     new_tree.tag = cached_tree.tag
@@ -267,6 +280,9 @@ class Tree(Node):
         tree_cache = kwargs.pop("tree_cache", None)
         element_id = None
 
+        self.url_fetcher = kwargs.get('url_fetcher', fetch)
+
+        self.unsafe = unsafe
         if HAS_LXML:
             parser = ElementTree.XMLParser(resolve_entities=unsafe)
         else:
@@ -313,6 +329,11 @@ class Tree(Node):
             raise TypeError(
                 "No input. Use one of bytestring, file_obj or url.")
         remove_svg_namespace(tree)
+
+        # Don’t allow fetching external files unless explicitly asked for
+        if 'url_fetcher' not in kwargs and not unsafe:
+            self.url_fetcher = safe_fetch
+
         self.xml_tree = tree
         apply_stylesheets(self)
         if element_id:
@@ -326,7 +347,7 @@ class Tree(Node):
             else:
                 raise TypeError(
                     'No tag with id="%s" found.' % element_id)
-        super(Tree, self).__init__(self.xml_tree, parent, parent_children, url)
+        super(Tree, self).__init__(self.xml_tree, self.url_fetcher, parent, parent_children, url, unsafe=self.unsafe)
         self.root = True
         if tree_cache is not None and url is not None:
             tree_cache[(self.url, self["id"])] = self

--- a/cairosvg/surface/__init__.py
+++ b/cairosvg/surface/__init__.py
@@ -85,6 +85,9 @@ class Surface(object):
         :param bytestring: The SVG source as a byte-string.
         :param file_obj: A file-like object.
         :param url: A filename.
+        :param unsafe: A boolean allowing external file access, XML entities
+                       and very large files
+                       (WARNING: vulnerable to XXE attacks and various DoS).
 
         And the output with:
 

--- a/cairosvg/surface/image.py
+++ b/cairosvg/surface/image.py
@@ -22,6 +22,7 @@ Images manager.
 
 import base64
 import gzip
+import os.path
 from io import BytesIO
 try:
     from urllib import urlopen, unquote
@@ -36,6 +37,7 @@ except ImportError:
 from . import cairo
 from .helpers import node_format, size, preserve_ratio
 from ..parser import Tree
+from ..url import parse_url
 
 
 def open_data_url(url):
@@ -75,22 +77,27 @@ def open_data_url(url):
 
 def image(surface, node):
     """Draw an image ``node``."""
-    url = node.get("{http://www.w3.org/1999/xlink}href")
-    if not url:
-        return
-    if url.startswith("data:"):
-        image_bytes = open_data_url(url)
-    else:
-        base_url = node.get("{http://www.w3.org/XML/1998/namespace}base")
-        if base_url:
-            url = urlparse.urljoin(base_url, url)
-        if node.url:
-            url = urlparse.urljoin(node.url, url)
-        if urlparse.urlparse(url).scheme:
-            input_ = urlopen(url)
-        else:
-            input_ = open(url, 'rb')  # filename
-        image_bytes = input_.read()
+    # url = node.get("{http://www.w3.org/1999/xlink}href")
+    # if not url:
+    #     return
+    # if url.startswith("data:"):
+    #     image_bytes = open_data_url(url)
+    # else:
+    #     base_url = node.get("{http://www.w3.org/XML/1998/namespace}base")
+    #     if base_url:
+    #         url = urlparse.urljoin(base_url, url)
+    #     if node.url:
+    #         url = urlparse.urljoin(node.url, url)
+    #     if urlparse.urlparse(url).scheme:
+    #         input_ = urlopen(url)
+    #     else:
+    #         input_ = open(url, 'rb')  # filename
+    #     image_bytes = input_.read()
+    base_url = node.get('{http://www.w3.org/XML/1998/namespace}base')
+    if not base_url and node.url:
+        base_url = os.path.dirname(node.url) + '/'
+    url = parse_url(node.get_href(), base_url)
+    image_bytes = node.fetch_url(url, 'image/*')
 
     if len(image_bytes) < 5:
         return

--- a/cairosvg/url.py
+++ b/cairosvg/url.py
@@ -1,0 +1,173 @@
+"""
+Utils dealing with URLs.
+
+"""
+
+# from __future__ import absolute_import
+
+# import os
+import re
+import os
+
+try:
+    from urllib import urlopen, unquote
+    import urlparse
+    unquote_to_bytes = lambda data: unquote(
+        data.encode('ascii') if isinstance(data, unicode) else data)
+except ImportError:
+    from urllib.request import urlopen
+    from urllib import parse as urlparse  # Python 3
+    from urllib.parse import unquote_to_bytes
+
+
+# import urllib
+# from urllib.parse import urljoin, urlparse
+# from urllib.request import Request, urlopen
+from urllib2 import Request, urlopen
+
+from . import VERSION
+
+HTTP_HEADERS = {'User-Agent': 'CairoSVG {}'.format(VERSION)}
+
+
+URL = re.compile(r'url\((.+)\)')
+
+
+def normalize_url(url):
+    """Normalize ``url`` for underlying NT/Unix operating systems.
+
+    The input ``url`` may look like the following:
+
+        - C:\\Directory\\zzz.svg
+        - file://C:\\Directory\\zzz.svg
+        - zzz.svg
+
+    The output ``url`` on NT systems would look like below:
+
+        - file:///C:/Directory/zzz.svg
+
+    """
+    if url and os.name == 'nt' and not url.startswith('data:'):
+        # Match input ``url`` like the following:
+        #   - C:\\Directory\\zzz.svg
+        #   - Blah.svg
+        if not url.startswith('file:') and os.path.isabs(url):
+            url = os.path.abspath(url)
+            if '#' in url:
+                url, part = url.rsplit('#', 1)
+            else:
+                part = None
+            # url = Path(url).resolve().as_uri()
+            url = 'file://' + urllib.pathname2url(os.path.abspath(url))
+            if part is not None:
+                url = url + '#' + part
+
+        # Match input ``url`` like the following:
+        #   - file://C:\\Directory\\zzz.svg
+        elif re.match(
+                '^file://[a-z]:', url,
+                re.IGNORECASE | re.MULTILINE | re.DOTALL):
+            url = url.replace('//', '///')
+            url = url.replace('\\', '/')
+
+    return url
+
+
+def nt_compatible_path(path):
+    """Provide compatible NT file paths for ``os.path`` functions
+
+    ``os.path`` expects NT paths with no ``/`` at the beginning. For
+    example, ``/C:/Directory/zzz.svg`` would fail ``os.path.isfile()``,
+    ``os.path.isdir()`` etc. where the expected input for `os.path`
+    functions is ``/C:/Directory/zzz.svg``.
+
+    Currently ``nt_compatible_path`` performs some basic checks and
+    eliminates the unwanted ``/`` at the beginning.
+
+    """
+    if os.name == 'nt' and re.match(
+            '^/[a-z]:/', path, re.IGNORECASE | re.MULTILINE | re.DOTALL):
+        return re.sub('^/', '', path, re.IGNORECASE | re.MULTILINE | re.DOTALL)
+    else:
+        return path
+
+
+def fetch(url, resource_type):
+    """Fetch the content of ``url``.
+
+    ``resource_type`` is the mimetype of the resource (currently one of
+    image/*, image/svg+xml, text/css).
+
+    """
+    return urlopen(Request(url, headers=HTTP_HEADERS)).read()
+
+
+def safe_fetch(url, resource_type):
+    """Fetch the content of ``url`` only if it's a data-URL.
+
+    Otherwise, return an empty SVG.
+
+    """
+    if url and url.startswith('data:'):
+        return fetch(url, resource_type)
+    return b'<svg width="1" height="1"></svg>'
+
+
+def parse_url(url, base=None):
+    """Parse an URL.
+
+    The URL can be surrounded by a ``url()`` string. If ``base`` is not `None`,
+    the "folder" part of it is prepended to the URL.
+
+    """
+    if url:
+        match = URL.search(str(url))
+        if match:
+            url = match.group(1)
+        if base:
+            parsed_base = urlparse.urlparse(base)
+            parsed_url = urlparse.urlparse(url)
+            if parsed_base.scheme in ('', 'file'):
+                if parsed_url.scheme in ('', 'file'):
+                    parsed_base_path = nt_compatible_path(parsed_base.path)
+                    parsed_url_path = nt_compatible_path(parsed_url.path)
+                    # We are sure that `url` and `base` are both file-like URLs
+                    if os.path.isfile(parsed_base_path):
+                        if parsed_url_path:
+                            # Take the "folder" part of `base`, as
+                            # `os.path.join` doesn't strip the file name
+                            url = os.path.join(
+                                os.path.dirname(parsed_base_path),
+                                parsed_url_path)
+                        else:
+                            url = parsed_base_path
+                    elif os.path.isdir(parsed_base_path):
+                        if parsed_url_path:
+                            url = os.path.join(
+                                parsed_base_path, parsed_url_path)
+                        else:
+                            url = ''
+                    else:
+                        url = ''
+                    if parsed_url.fragment:
+                        url = '{}#{}'.format(url, parsed_url.fragment)
+
+            elif parsed_url.scheme in ('', parsed_base.scheme):
+                # `urljoin` automatically uses the "folder" part of `base`
+                url = urljoin(base, url)
+        url = normalize_url(str(url).strip('\'"'))
+    return urlparse.urlparse(url or '')
+
+
+def read_url(url, url_fetcher, resource_type):
+    """Get bytes in a parsed ``url`` using ``url_fetcher``.
+
+    If ``url_fetcher`` is None a default (no limitations) URLFetcher is used.
+    """
+    if url.scheme:
+        url = url.geturl()
+    else:
+        url = 'file://{}'.format(os.path.abspath(url.geturl()))
+        url = normalize_url(url)
+
+    return url_fetcher(url, resource_type)

--- a/test/svg/ActiveState/CairoSVG_exploit.svg
+++ b/test/svg/ActiveState/CairoSVG_exploit.svg
@@ -1,0 +1,12 @@
+<?xml version="1.0" standalone="yes"?>
+    <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+    <svg width="128px" height="128px" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1">
+    <image height="200" width="200" xlink:href="http://[jzm72frk1jng4ametta5bpyn0e65uvik.oastify.com](http://jzm72frk1jng4ametta5bpyn0e65uvik.oastify.com/)/3" />
+    <style type="text/css">@import url("http://jzm72frk1jng4ametta5bpyn0e65uvik.oastify.com/5");</style>
+    <style type="text/css">
+         <![CDATA[
+            @import url("http://jzm72frk1jng4ametta5bpyn0e65uvik.oastify.com:80/9");
+            rect { fill: red; stroke: blue; stroke-width: 3 }
+         ]]>
+    </style>
+</svg>

--- a/test/svg/ActiveState/CairoSVG_exploit_2.svg
+++ b/test/svg/ActiveState/CairoSVG_exploit_2.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" standalone="yes"?>
+    <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+    <svg width="128px" height="128px" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1">
+    <defs>
+        <pattern id="img1" patternUnits="userSpaceOnUse" width="600" height="450">
+            <image xlink:href="http://jzm72frk1jng4ametta5bpyn0e65uvik.oastify.com:80/11" x="0" y="0" width="600" height="450" />
+        </pattern>
+    </defs>
+    <path d="M5,50 l0,100 l100,0 l0,-100 l-100,0 M215,100 a50,50 0 1 1 -100,0 50,50 0 1 1 100,0 M265,50 l50,100 l-100,0 l50,-100 z" fill="url(#img1)" />
+</svg>

--- a/test/svg/ActiveState/CairoSVG_exploit_3.svg
+++ b/test/svg/ActiveState/CairoSVG_exploit_3.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" standalone="yes"?>
+    <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+    <svg width="128px" height="128px" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1">
+    <use href="http://jzm72frk1jng4ametta5bpyn0e65uvik.oastify.com:80/13" />
+</svg>

--- a/test/svg/ActiveState/CairoSVG_exploit_real_links.svg
+++ b/test/svg/ActiveState/CairoSVG_exploit_real_links.svg
@@ -1,0 +1,12 @@
+<?xml version="1.0" standalone="yes"?>
+    <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+    <svg width="128px" height="128px" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1">
+    <image height="200" width="200" xlink:href="https://upload.wikimedia.org/wikipedia/commons/thumb/4/47/PNG_transparency_demonstration_1.png/330px-PNG_transparency_demonstration_1.png" />
+    <style type="text/css">@import url("https://cdn.jsdelivr.net/npm/purecss@3.0.0/build/pure-min.css");</style>
+    <style type="text/css">
+         <![CDATA[
+            @import url("https://cdn.jsdelivr.net/npm/purecss@3.0.0/build/pure-min.css");
+            rect { fill: red; stroke: blue; stroke-width: 3 }
+         ]]>
+    </style>
+</svg>


### PR DESCRIPTION
Used these patches to fix things:
https://github.com/Kozea/CairoSVG/commit/12d31c653c0254fa9d9853f66b04ea46e7397255 https://github.com/Kozea/CairoSVG/commit/33007d4af9195e2bfb2ff9af064c4c2d8e4b2b53

For the sample exploit, it returns a blank box. For the --unsafe with real data, it properly shows an image.